### PR TITLE
fix the bugs in doc2json installation script

### DIFF
--- a/README_details.md
+++ b/README_details.md
@@ -17,7 +17,9 @@
 The current `doc2json` tool uses Grobid to first process each PDF into XML, then extracts paper components from the XML.
 If you fail to install Doc2Json or Grobid with `bin/doc2json/scripts/run.sh` , try to execute the following command:
 ```bash
-python bin/doc2json/setup.py develop
+cd bin/doc2json
+python setup.py develop
+cd ../..
 ```
 This will setup Doc2Json.
 

--- a/bin/doc2json/scripts/run.sh
+++ b/bin/doc2json/scripts/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-python bin/doc2json/setup.py develop
+cd bin/doc2json
+python setup.py develop
+cd ../..
 bash bin/doc2json/scripts/setup_grobid.sh
 nohup bash bin/doc2json/scripts/run_grobid.sh >/dev/null 2>grobid_log &
 

--- a/bin/doc2json/scripts/setup_grobid.sh
+++ b/bin/doc2json/scripts/setup_grobid.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # put in your pdf2json directory here
-export PDF2JSON_HOME=$HOME/git/s2orc-pdf2json
-
+export PDF2JSON_HOME=$(cd "$(dirname "$0")";cd ..;pwd)
+echo $PDF2JSON_HOME
 # Download Grobid
 cd $HOME
 wget https://github.com/kermitt2/grobid/archive/0.6.1.zip
@@ -15,7 +15,7 @@ cd $HOME/grobid-0.6.1
 # increase max.connections to slightly more than number of processes
 # decrease logging level
 # this isn't necessary but is nice to have if you are processing lots of files
-cp $PDF2JSON_HOME/pdf2json/grobid/config.yaml $HOME/grobid-0.6.1/grobid-service/config/config.yaml
-cp $PDF2JSON_HOME/pdf2json/grobid/grobid.properties $HOME/grobid-0.6.1/grobid-home/config/grobid.properties
+cp $PDF2JSON_HOME/doc2json/grobid2json/grobid/config.yaml $HOME/grobid-0.6.1/grobid-service/config/config.yaml
+cp $PDF2JSON_HOME/doc2json/grobid2json/grobid/grobid.properties $HOME/grobid-0.6.1/grobid-home/config/grobid.properties
 
 


### PR DESCRIPTION
Reassigned the installation directory to avoid the ModuleNotFoundError.
Run setup.py in the bin/doc2json dir so that a .pth file is generated automatically which contains the path of the doc2json module. 